### PR TITLE
Do not use cpp as tempfile_suffix

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -20,7 +20,7 @@ class Cpplint(Linter):
     syntax = 'c++'
     cmd = ('cpplint', '*', '@')
     regex = r'^.+:(?P<line>\d+):\s+(?P<message>.+)'
-    tempfile_suffix = '.cpp'
+    tempfile_suffix = '-'
     error_stream = util.STREAM_BOTH  # errors are on stderr
     defaults = {
         '--filter=,': '',


### PR DESCRIPTION
This is to fix https://github.com/SublimeLinter/SublimeLinter-cpplint/issues/1 and https://github.com/SublimeLinter/SublimeLinter-cpplint/issues/5

I know it's not perfect but at least it's a bit better, and then people can add --root if their linter supports it.