### PR TITLE
cleanup for SL4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,7 @@
 language: python
 python:
-  - "3.3"
-# command to install dependencies
+  - "3.6"
 install:
   - pip install flake8
-  - pip install pydocstyle
-# command to run tests
 script:
   - flake8 . --max-line-length=120
-  - pydocstyle . --add-ignore=D202

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ SublimeLinter-cpplint
 This linter plugin for SublimeLinter provides an interface to [cpplint](https://pypi.python.org/pypi/cpplint). It will be used with files that have the "C" or “C++” syntax.
 
 ## Installation
+
 SublimeLinter must be installed in order to use this plugin.
 
 Please use [Package Control](https://packagecontrol.io) to install the linter plugin.
@@ -19,12 +20,13 @@ Before using this plugin, you must ensure that `cpplint` is installed on your sy
    [sudo] pip install cpplint
    ```
 
-In order for `cpplint` to be executed by SublimeLinter, you must ensure that its path is available to SublimeLinter. The docs cover [troubleshooting PATH configuration](http://sublimelinter.readthedocs.io/en/latest/troubleshooting.html#finding-a-linter-executable).
+In order for `cpplint` to be executed by SublimeLinter, you must ensure that its path is available to SublimeLinter. The docs cover [troubleshooting PATH configuration](http://sublimelinter.com/en/latest/troubleshooting.html#finding-a-linter-executable).
 
 
 ## Settings
-- SublimeLinter settings: http://sublimelinter.readthedocs.org/en/latest/settings.html
-- Linter settings: http://sublimelinter.readthedocs.org/en/latest/linter_settings.html
+
+- SublimeLinter settings: http://sublimelinter.com/en/latest/settings.html
+- Linter settings: http://sublimelinter.com/en/latest/linter_settings.html
 
 Additional settings for SublimeLinter-cpplint
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ SublimeLinter-cpplint
 
 [![Build Status](https://travis-ci.org/SublimeLinter/SublimeLinter-cpplint.svg?branch=master)](https://travis-ci.org/SublimeLinter/SublimeLinter-cpplint)
 
-This linter plugin for SublimeLinter provides an interface to [cpplint](https://pypi.python.org/pypi/cpplint). It will be used with files that have the "C" or “C++” syntax.
+This linter plugin for SublimeLinter provides an interface to [cpplint](https://pypi.python.org/pypi/cpplint).
+It will be used with files that have the "C" or "C++" syntax.
 
 ## Installation
 
@@ -11,7 +12,8 @@ SublimeLinter must be installed in order to use this plugin.
 
 Please use [Package Control](https://packagecontrol.io) to install the linter plugin.
 
-Before using this plugin, you must ensure that `cpplint` is installed on your system. To install `cpplint`, do the following:
+Before using this plugin, ensure that `cpplint` is installed on your system.
+To install `cpplint`, do the following:
 
 1. Install [Python](http://python.org/download/) and [pip](http://www.pip-installer.org/en/latest/installing.html).
 
@@ -20,7 +22,8 @@ Before using this plugin, you must ensure that `cpplint` is installed on your sy
    [sudo] pip install cpplint
    ```
 
-In order for `cpplint` to be executed by SublimeLinter, you must ensure that its path is available to SublimeLinter. The docs cover [troubleshooting PATH configuration](http://sublimelinter.com/en/latest/troubleshooting.html#finding-a-linter-executable).
+Please make sure that the path to `cpplint` is available to SublimeLinter.
+The docs cover [troubleshooting PATH configuration](http://sublimelinter.com/en/latest/troubleshooting.html#finding-a-linter-executable).
 
 
 ## Settings

--- a/linter.py
+++ b/linter.py
@@ -1,33 +1,16 @@
-#
-# linter.py
-# Linter for SublimeLinter3, a code checking framework for Sublime Text 3
-#
-# Written by NotSqrt
-# Copyright (c) 2013 NotSqrt
-#
-# License: MIT
-#
-
-"""This module exports the Cpplint plugin class."""
-
 from SublimeLinter.lint import Linter, util
 
 
 class Cpplint(Linter):
-    """Provides an interface to cpplint."""
-
-    syntax = ('c++', 'c')
-    cmd = ('cpplint', '*', '@')
+    cmd = ('cpplint', '${args}', '${file}')
     regex = r'^.+:(?P<line>\d+):\s+(?P<message>.+)'
     tempfile_suffix = '-'
     error_stream = util.STREAM_BOTH  # errors are on stderr
     defaults = {
+        'selector': 'source.c, source.c++',
         '--filter=,': '',
         '--linelength=,': '',
     }
-    comment_re = r'\s*/[/*]'
-    inline_settings = None
-    inline_overrides = ['filter', 'linelength']
 
     def split_match(self, match):
         """

--- a/messages.json
+++ b/messages.json
@@ -1,5 +1,3 @@
 {
-    "install": "messages/install.txt",
-    "1.0.8": "messages/1.0.8.txt",
-    "1.0.9": "messages/1.0.9.txt"
+    "install": "messages/install.txt"
 }

--- a/messages/1.0.8.txt
+++ b/messages/1.0.8.txt
@@ -1,6 +1,0 @@
-SublimeLinter-cpplint
--------------------------------
-Inline settings will be no longer be supported in SublimeLinter 4.
-Please use cppcheck configuration files etc. instead.
-
-https://github.com/SublimeLinter/SublimeLinter3/blob/next/messages/4.0.0-rc.1.txt

--- a/messages/1.0.9.txt
+++ b/messages/1.0.9.txt
@@ -1,3 +1,0 @@
-SublimeLinter-cpplint
--------------------------------
-Will now also lint files with the C syntax.


### PR DESCRIPTION
- lint using python 3.6
- no pydocstyle lint
- remove comments and old messages
- non-crypto args
- use selector